### PR TITLE
Add user setup page and update homepage navigation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
               Collaborative conversations with friends, teams, and an AI facilitator that only joins when it should.
             </p>
             <div className="space-y-4">
-              <Link href="/multi-user-chat">
+              <Link href="/user-setup">
                 <button className="bg-[#A8C3A0] hover:bg-[#9BB396] text-white px-8 py-4 rounded-full text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-200">
                   Enter Chat
                 </button>
@@ -162,7 +162,7 @@ export default function Home() {
           <h2 className="text-4xl font-bold text-[#2D2D2D] mb-8">
             Start a conversation today.
           </h2>
-          <Link href="/multi-user-chat">
+          <Link href="/user-setup">
             <button className="bg-[#A8C3A0] hover:bg-[#9BB396] text-white px-8 py-4 rounded-full text-lg font-semibold shadow-lg hover:shadow-xl transition-all duration-200">
               Get Started
             </button>

--- a/src/app/user-setup/page.tsx
+++ b/src/app/user-setup/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { MultiUserChatProvider } from '@/components/multiUserChat/MultiUserChatProvider';
+import { UserSetup } from '@/components/multiUserChat/UserSetup';
+
+function UserSetupContent() {
+  const router = useRouter();
+
+  const handleSetupComplete = () => {
+    // Redirect to the multi-user chat page after setup is complete
+    router.push('/multi-user-chat');
+  };
+
+  return (
+    <div className="min-h-screen">
+      <UserSetup onComplete={handleSetupComplete} />
+    </div>
+  );
+}
+
+export default function UserSetupPage() {
+  return (
+    <MultiUserChatProvider>
+      <UserSetupContent />
+    </MultiUserChatProvider>
+  );
+}


### PR DESCRIPTION
- Updated homepage buttons to route to /user-setup instead of /multi-user-chat
- Created new user setup page at /user-setup with name input and avatar selection
- User setup page redirects to multi-user-chat after completion
- Improved user flow: Homepage → User Setup → Multi-User Chat